### PR TITLE
Update base image to alpine:3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.10
 RUN apk --update add postgresql-client \
     bash \
     && \


### PR DESCRIPTION
The postgres-client version which is installed with alpine:3.7 is 10.9 and is not compatible with postgres@11.2 as used by our service in AWS.

Updating alpine to 3.10 installs postgres-client@11.4, which supports all recent versions of postgres.